### PR TITLE
Fix Windows build break by adding new dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,10 @@ deploy:
     - dist/docker-volume-glusterfs-${VERSION}-freebsd_amd64.tar.gz
     - dist/docker-volume-glusterfs-${VERSION}-freebsd_386.zip
     - dist/docker-volume-glusterfs-${VERSION}-freebsd_386.tar.gz
+    - dist/docker-volume-glusterfs-${VERSION}-windows_386.zip
+    - dist/docker-volume-glusterfs-${VERSION}-windows_386.tar.gz
+    - dist/docker-volume-glusterfs-${VERSION}-windows_amd64.zip
+    - dist/docker-volume-glusterfs-${VERSION}-windows_amd64.tar.gz
   skip_cleanup: true
   overwrite: true
   on:

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 
 BUILD               = $(shell git rev-parse HEAD)
 
-PLATFORMS           = linux_amd64 linux_386 linux_arm darwin_amd64 darwin_386 freebsd_amd64 freebsd_386
+PLATFORMS           = windows_amd64
 
 FLAGS_all           = GOPATH=$(GOPATH)
 FLAGS_linux_amd64   = $(FLAGS_all) GOOS=linux GOARCH=amd64

--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,7 @@ deps:
 	go get github.com/coreos/go-systemd/activation
 	go get github.com/opencontainers/runc/libcontainer/user
 	go get -d github.com/Microsoft/go-winio
+	go get golang.org/x/sys/windows
 .PHONY: deps
 
 install: guard-VERSION build

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 
 BUILD               = $(shell git rev-parse HEAD)
 
-PLATFORMS           = windows_amd64
+PLATFORMS           = linux_amd64 linux_386 linux_arm darwin_amd64 darwin_386 freebsd_amd64 freebsd_386 windows_386 windows_amd64
 
 FLAGS_all           = GOPATH=$(GOPATH)
 FLAGS_linux_amd64   = $(FLAGS_all) GOOS=linux GOARCH=amd64


### PR DESCRIPTION
Windows builds were broken because Microsoft uses the golang.org/x/sys/windows library in their go-winio library. This dependency was added many months ago. I do not know why Windows builds (apparently) worked in the past. Perhaps TravisCI used to install the package by default; after all, it is from the golang repository. At any rate, installing it during the dependency acquisition step resolves the issue.